### PR TITLE
Fix spin animation on firefox

### DIFF
--- a/client/screen.css
+++ b/client/screen.css
@@ -1511,6 +1511,16 @@ code {
     -o-transition: color .25s, text-shadow .25s, background .25s, opacity .25s;
 }
 
+@keyframes spin {
+    0% {
+        transform: rotate(0);
+    }
+
+    100% {
+        transform: rotate(360deg);
+    }
+}
+
 @-webkit-keyframes spin {
     0% {
         -webkit-transform: rotate(0);


### PR DESCRIPTION
Updated `client/screen.css` to include a `@keyframes spin`  rule to fix the spin animation in Firefox.
Apparently the `-moz-` vendor prefix hasn't done anything since 2013.