### PR TITLE
Fix noPreventDefault bug

### DIFF
--- a/client/script.js
+++ b/client/script.js
@@ -2,6 +2,9 @@ const translation = window.i18nextify.init({
   autorun: false,
 });
 
+if (localStorage.noPreventDefault == undefined) {
+  localStorage.setItem("noPreventDefault", false)
+}
 if (location.host === "multiplayerpiano.com") {
   const url = new URL("https://multiplayerpiano.net/" + location.search);
   if (localStorage.token) url.searchParams.set("token", localStorage.token);
@@ -4954,8 +4957,12 @@ $(function() {
               true,
               html,
               () => {
+                // invert gNoPreventDefault variable
                 gNoPreventDefault = !gNoPreventDefault;
-                localStorage.noPreventDefault = noPreventDefault;
+                // set localStorage.noPreventDefault to gNoPreventDefault
+                localStorage.setItem('noPreventDefault', gNoPreventDefault);
+                // set gNoPreventDefault to localStorage.noPreventDefault to check if the process worked
+                gNoPreventDefault = localStorage.noPreventDefault == "true";
               },
             );
 

--- a/client/script.js
+++ b/client/script.js
@@ -2,9 +2,6 @@ const translation = window.i18nextify.init({
   autorun: false,
 });
 
-if (!("noPreventDefault" in localStorage)) {
-  localStorage.noPreventDefault = "false"
-}
 if (location.host === "multiplayerpiano.com") {
   const url = new URL("https://multiplayerpiano.net/" + location.search);
   if (localStorage.token) url.searchParams.set("token", localStorage.token);

--- a/client/script.js
+++ b/client/script.js
@@ -4955,7 +4955,7 @@ $(function() {
               html,
               () => {
                 gNoPreventDefault = !gNoPreventDefault;
-                localStorage.noPreventDefault = gNoPreventDefault
+                localStorage.noPreventDefault = gNoPreventDefault;
               },
             );
 

--- a/client/script.js
+++ b/client/script.js
@@ -2,8 +2,8 @@ const translation = window.i18nextify.init({
   autorun: false,
 });
 
-if (localStorage.noPreventDefault == undefined) {
-  localStorage.setItem("noPreventDefault", false)
+if (!("noPreventDefault" in localStorage)) {
+  localStorage.noPreventDefault = "false"
 }
 if (location.host === "multiplayerpiano.com") {
   const url = new URL("https://multiplayerpiano.net/" + location.search);
@@ -4957,12 +4957,8 @@ $(function() {
               true,
               html,
               () => {
-                // invert gNoPreventDefault variable
                 gNoPreventDefault = !gNoPreventDefault;
-                // set localStorage.noPreventDefault to gNoPreventDefault
-                localStorage.setItem('noPreventDefault', gNoPreventDefault);
-                // set gNoPreventDefault to localStorage.noPreventDefault to check if the process worked
-                gNoPreventDefault = localStorage.noPreventDefault == "true";
+                localStorage.noPreventDefault = gNoPreventDefault
               },
             );
 


### PR DESCRIPTION
Added pull request to fix recently-opened issue about noPreventDefault option on client settings

Added comments to detail procedure

Fixes:
On open, check if `localStorage.noPreventDefault` exists, if not, create variable and set to false by default, as done by the site.
When setting `localStorage.noPreventDefault`, it set to a non-existent variable (`noPreventDefault`). This was fixed by using the variable `gNoPreventDefault`, that actually existed. Also changed to use `localStorage.setItem()`, for my own sanity. 