### PR TITLE
Fix token vulnerability problem

### DIFF
--- a/client/Client.js
+++ b/client/Client.js
@@ -2,6 +2,7 @@ WebSocket.prototype.send = new Proxy(WebSocket.prototype.send, {
   apply: (target, thisArg, args) => {
     if (localStorage.token && !args[0].startsWith(`[{"m":"hi"`))
       args[0] = args[0].replace(localStorage.token, "[REDACTED]");
+      args[0] = args[0].replace(btoa(localStorage.token), "[REDACTED]");
     return target.apply(thisArg, args);
   },
 });


### PR DESCRIPTION
the token censoring filter had an oversight, where just converting the token to base64 using `btoa()`, the token could be sent, and it could be easily decoded using `atob()` 