### PR TITLE
Remove old Discord Discriminator Tags

### DIFF
--- a/client/script.js
+++ b/client/script.js
@@ -2849,9 +2849,7 @@ $(function() {
       if (gClient.accountInfo.type === "discord") {
         $("#account #avatar-image").prop("src", gClient.accountInfo.avatar);
         $("#account #logged-in-user-text").text(
-          gClient.accountInfo.username +
-          "#" +
-          gClient.accountInfo.discriminator,
+          gClient.accountInfo.username
         );
       }
     } else {


### PR DESCRIPTION
Remove old Discord Discriminator Tags in the account page.

Old:
<img width="433" height="333" alt="image" src="https://github.com/user-attachments/assets/7043bc64-e8c9-4217-b346-396102e790c6" />

New:
<img width="433" height="333" alt="image" src="https://github.com/user-attachments/assets/3dbb8039-0819-49ba-bf88-9431bbf72248" />
