### PR TITLE
Remove old discriminator tags

### DIFF
--- a/client/script.js
+++ b/client/script.js
@@ -2849,7 +2849,7 @@ $(function() {
       if (gClient.accountInfo.type === "discord") {
         $("#account #avatar-image").prop("src", gClient.accountInfo.avatar);
         $("#account #logged-in-user-text").text(
-          gClient.accountInfo.username
+          "@" + gClient.accountInfo.username
         );
       }
     } else {


### PR DESCRIPTION
Remove the old Discord discriminator tags
Old:
<img width="433" height="333" alt="image" src="https://github.com/user-attachments/assets/e059e868-9af7-43a8-97c9-1c10fad31a5f" />
New:
<img width="436" height="334" alt="image" src="https://github.com/user-attachments/assets/b6cbae76-aeb7-4dd1-8fb3-c7e81e66f855" />