### PR TITLE
Fix Portuguese translations in translation.json

### DIFF
--- a/client/locales/pt/translation.json
+++ b/client/locales/pt/translation.json
@@ -86,7 +86,7 @@
     "triangle": "triangular",
     "sine": "ondular",
     "sawtooth": "dente de serra",
-    "Disable MIDI Drum Channel (channel 10):": "Desligar canal de Bateria do MIDI (canal 10):",
+    "Disable MIDI Drum Channel (channel 10):": "Desligar canal de bateria do MIDI (canal 10):",
     "Show piano notes:": "Mostrar notas do piano:",
     "Don't use prevent default:": "Não usar preventDefault():",
     "Force dark background:": "Forçar fundo preto:",


### PR DESCRIPTION
don't remove the joke in the translation for My Fancy New Name, for the joke's sake