### PR TITLE
fix xss in chat mention color and audio note stealing

### DIFF
--- a/src/modules/chat.ts
+++ b/src/modules/chat.ts
@@ -389,7 +389,8 @@ export function initChat(): Chat {
 								setYoureMentioned(true);
 								document.title = i18next.t('You were mentioned!');
 							}
-							return `<span class="mention" style="background-color: ${user.color};">${nick}</span>`;
+							const mentionColor = /^#[0-9a-fA-F]{3,8}$/.test(user.color || '') ? user.color : '#777';
+							return `<span class="mention" style="background-color: ${mentionColor};">${nick}</span>`;
 						} else return `@${nick}`;
 					} else return match;
 				},

--- a/src/piano/audio.ts
+++ b/src/piano/audio.ts
@@ -113,8 +113,8 @@ export class AudioEngineWeb extends AudioEngine {
 		source.connect(gain);
 		gain.connect(this.pianoGain);
 		source.start(time);
-		if (this.playings[id]) {
-			const playing = this.playings[id];
+		if (this.playings[id + ':' + part_id]) {
+			const playing = this.playings[id + ':' + part_id];
 			playing.gain.gain.setValueAtTime(playing.gain.gain.value, time);
 			playing.gain.gain.linearRampToValueAtTime(0.0, time + 0.2);
 			playing.source.stop(time + 0.21);
@@ -122,9 +122,9 @@ export class AudioEngineWeb extends AudioEngine {
 				playing.voice.stop(time);
 			}
 		}
-		this.playings[id] = { source, gain, part_id };
+		this.playings[id + ':' + part_id] = { source, gain, part_id };
 		if (state.enableSynth && state.synthVoice) {
-			this.playings[id].voice = new state.synthVoice(id, time);
+			this.playings[id + ':' + part_id].voice = new state.synthVoice(id, time);
 		}
 	}
 	play(id: string, vol: number, delay_ms: number, part_id: string): void {
@@ -142,19 +142,19 @@ export class AudioEngineWeb extends AudioEngine {
 
 	actualStop(id: string, time: number, part_id: string): void {
 		if (
-			this.playings.hasOwnProperty(id) &&
-			this.playings[id] &&
-			this.playings[id].part_id === part_id
+			this.playings.hasOwnProperty(id + ':' + part_id) &&
+			this.playings[id + ':' + part_id] &&
+			this.playings[id + ':' + part_id].part_id === part_id
 		) {
-			const gain = this.playings[id].gain.gain;
+			const gain = this.playings[id + ':' + part_id].gain.gain;
 			gain.setValueAtTime(gain.value, time);
 			gain.linearRampToValueAtTime(gain.value * 0.1, time + 0.16);
 			gain.linearRampToValueAtTime(0.0, time + 0.4);
-			this.playings[id].source.stop(time + 0.41);
-			if (this.playings[id].voice) {
-				this.playings[id].voice.stop(time);
+			this.playings[id + ':' + part_id].source.stop(time + 0.41);
+			if (this.playings[id + ':' + part_id].voice) {
+				this.playings[id + ':' + part_id].voice.stop(time);
 			}
-			this.playings[id] = null;
+			this.playings[id + ':' + part_id] = null;
 		}
 	}
 


### PR DESCRIPTION
i found two bugs reading the code.

chat.ts: user.color comes from the network and went straight into an innerHTML style attribute. a player can set their color to break out of the attribute and run js when you hover their mention. i now validate it against ^#[0-9a-fA-F]{3,8}$ and fall back to #777.

audio.ts: this.playings keyed only by note id. when two players hit the same key, the second play stopped the first voice, so notes got cut. i key it by id + ":" + part_id now, so each (note, participant) keeps its own voice.

verification:
- all this.playings reads use the same key (audio.ts) or loop without depending on the key format (synth.ts)
- part_id is participant.id, a string, so the key stays distinct per player
- tsc --noEmit passes for both files; only translations.ts fails on missing i18next modules, unrelated to this change